### PR TITLE
[fix bug] 函数调用，传入参数少入形式参数时，多出的形式参数值不确定

### DIFF
--- a/luna/State.cpp
+++ b/luna/State.cpp
@@ -276,6 +276,12 @@ namespace luna
         else
         {
             callee.register_ = arg;
+            // fill nil for overflow args
+            auto new_top = callee.register_ + fixed_args;
+            for (auto arg = stack_.top_; arg < new_top; arg++)
+            {
+                arg->SetNil();
+            }
         }
 
         stack_.SetNewTop(callee.register_ + fixed_args);


### PR DESCRIPTION
例子：
```
f1 = function (a,b)
    print(type(a).." "..type(b))
end
f1({2})
```
会输出 `table number`