### PR TITLE
[fix bug]添加个清空运行栈的指令，可以解决upval产生的bug。

### DIFF
--- a/luna/CodeGenerate.cpp
+++ b/luna/CodeGenerate.cpp
@@ -205,6 +205,10 @@ namespace luna
                                       it->second.begin_pc_, end_pc);
             }
 
+            // add one instruction to close block
+            auto instruction = Instruction::ABCode(OpType_FillNil, block->register_start_id_, current_function_->register_id_);
+            function->AddInstruction(instruction, 0);
+
             current_function_->current_block_ = block->parent_;
             current_function_->register_id_ = block->register_start_id_;
             delete block;

--- a/luna/OpCode.h
+++ b/luna/OpCode.h
@@ -6,6 +6,7 @@ namespace luna
     enum OpType
     {
         OpType_LoadNil = 1,             // A    A: register
+        OpType_FillNil,                 // AB   A: start reg B: end reg [A,B)
         OpType_LoadBool,                // AB   A: register B: 1 true 0 false
         OpType_LoadInt,                 // A    A: register Next instruction opcode is const unsigned int
         OpType_LoadConst,               // ABx  A: register Bx: const index

--- a/luna/State.cpp
+++ b/luna/State.cpp
@@ -276,6 +276,12 @@ namespace luna
         else
         {
             callee.register_ = arg;
+            // fill nil for overflow args
+            auto new_top = callee.register_ + fixed_args;
+            for (auto arg = stack_.top_; arg < new_top; arg++)
+            {
+                arg->SetNil();
+            }
         }
 
         stack_.SetNewTop(callee.register_ + fixed_args);

--- a/luna/VM.cpp
+++ b/luna/VM.cpp
@@ -28,8 +28,7 @@ namespace luna
 #define GET_REGISTER_B(i)       (call->register_ + Instruction::GetParamB(i))
 #define GET_REGISTER_C(i)       (call->register_ + Instruction::GetParamC(i))
 #define GET_UPVALUE_B(i)        (cl->GetUpvalue(Instruction::GetParamB(i)))
-#define GET_REAL_VALUE(a)       (a)
-//#define GET_REAL_VALUE(a)       (a->type_ == ValueT_Upvalue ? a->upvalue_->GetValue() : a)
+#define GET_REAL_VALUE(a)       (a->type_ == ValueT_Upvalue ? a->upvalue_->GetValue() : a)
 
 #define GET_REGISTER_ABC(i)                                 \
     a = GET_REGISTER_A(i);                                  \
@@ -78,6 +77,15 @@ namespace luna
                 case OpType_LoadNil:
                     a = GET_REGISTER_A(i);
                     GET_REAL_VALUE(a)->SetNil();
+                    break;
+                case OpType_FillNil:
+                    a = GET_REGISTER_A(i);
+                    b = GET_REGISTER_B(i);
+                    while (a < b)
+                    {
+                        a->SetNil();
+                        ++a;
+                    }
                     break;
                 case OpType_LoadBool:
                     a = GET_REGISTER_A(i);
@@ -348,13 +356,12 @@ namespace luna
                 {
                     auto upvalue = state_->NewUpvalue();
                     upvalue->SetValue(*reg);
-                    //reg->type_ = ValueT_Upvalue;
-                    //reg->upvalue_ = upvalue;
+                    reg->type_ = ValueT_Upvalue;
+                    reg->upvalue_ = upvalue;
                     new_closure->AddUpvalue(upvalue);
                 }
                 else
                 {
-                    assert(!"unreachable no reg change to upval");
                     new_closure->AddUpvalue(reg->upvalue_);
                 }
             }

--- a/luna/VM.cpp
+++ b/luna/VM.cpp
@@ -28,7 +28,8 @@ namespace luna
 #define GET_REGISTER_B(i)       (call->register_ + Instruction::GetParamB(i))
 #define GET_REGISTER_C(i)       (call->register_ + Instruction::GetParamC(i))
 #define GET_UPVALUE_B(i)        (cl->GetUpvalue(Instruction::GetParamB(i)))
-#define GET_REAL_VALUE(a)       (a->type_ == ValueT_Upvalue ? a->upvalue_->GetValue() : a)
+#define GET_REAL_VALUE(a)       (a)
+//#define GET_REAL_VALUE(a)       (a->type_ == ValueT_Upvalue ? a->upvalue_->GetValue() : a)
 
 #define GET_REGISTER_ABC(i)                                 \
     a = GET_REGISTER_A(i);                                  \
@@ -347,12 +348,13 @@ namespace luna
                 {
                     auto upvalue = state_->NewUpvalue();
                     upvalue->SetValue(*reg);
-                    reg->type_ = ValueT_Upvalue;
-                    reg->upvalue_ = upvalue;
+                    //reg->type_ = ValueT_Upvalue;
+                    //reg->upvalue_ = upvalue;
                     new_closure->AddUpvalue(upvalue);
                 }
                 else
                 {
+                    assert(!"unreachable no reg change to upval");
                     new_closure->AddUpvalue(reg->upvalue_);
                 }
             }


### PR DESCRIPTION
例子：
```
do
    local a = {}
    for i = 1,2 do
        a[i] = function() i = i+1; print(i); end
    end
    local b = 1 -- 如果这行不注释，下面执行会出错
    a[1]() 
end
```
问题在于栈结构没有有效的清空。